### PR TITLE
fix: Correct repository name in base href for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/turnord-oficial/' : '';
+  const baseHref = isGitHub ? '/TURNORD/' : '';
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/index_barberia005.html
+++ b/index_barberia005.html
@@ -8,7 +8,7 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/turnord-oficial/' : '';
+  const baseHref = isGitHub ? '/TURNORD/' : '';
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);


### PR DESCRIPTION
Updates the dynamic base href script in `index.html` and `index_barberia005.html`.

The hardcoded repository name was changed from `/turnord-oficial/` to `/TURNORD/` to match the user's GitHub Pages URL structure. This ensures that relative links resolve correctly when the site is deployed.