### PR TITLE
fix: Implement fully dynamic base href for GitHub Pages

### DIFF
--- a/cierre.html
+++ b/cierre.html
@@ -10,7 +10,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/cierre_barberia005.html
+++ b/cierre_barberia005.html
@@ -10,7 +10,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/configuracion.html
+++ b/configuracion.html
@@ -8,7 +8,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/configuracion_barberia005.html
+++ b/configuracion_barberia005.html
@@ -8,7 +8,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/turnord-oficial/' : '';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/index_barberia005.html
+++ b/index_barberia005.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/'; // Corregido para apuntar al repositorio correcto
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/login.html
+++ b/login.html
@@ -7,7 +7,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/login_barberia005.html
+++ b/login_barberia005.html
@@ -7,7 +7,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/negocio.html
+++ b/negocio.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/negocio_barberia005.html
+++ b/negocio_barberia005.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/panel.html
+++ b/panel.html
@@ -10,7 +10,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/panel_barberia005.html
+++ b/panel_barberia005.html
@@ -10,7 +10,15 @@
  <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/turno.html
+++ b/turno.html
@@ -8,7 +8,15 @@
   <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -8,7 +8,15 @@
   <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/usuario.html
+++ b/usuario.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);

--- a/usuario_barberia005.html
+++ b/usuario_barberia005.html
@@ -8,7 +8,15 @@
 <!-- Base dinámico -->
 <script>
   const isGitHub = location.hostname.includes('github.io');
-  const baseHref = isGitHub ? '/TURNORD/' : '/';
+  let baseHref = '/';
+  if (isGitHub) {
+    // Pathname on GitHub Pages is /<repo-name>/...
+    const pathParts = location.pathname.split('/');
+    // The repo name is the first part of the path after the initial slash
+    if (pathParts.length > 1 && pathParts[1]) {
+      baseHref = `/${pathParts[1]}/`;
+    }
+  }
   const base = document.createElement('base');
   base.href = baseHref;
   document.head.appendChild(base);


### PR DESCRIPTION
This commit replaces the previously hardcoded dynamic base href script with a more robust version. The new script automatically detects the repository name from the window.location.pathname, making the application's routing independent of the repository name.

This change was applied to all 16 root-level HTML files and is intended to resolve the 404 "Not Found" errors that were occurring during navigation on the deployed GitHub Pages site.