### PR TITLE
feat: Integrate voice commands for turn management

### DIFF
--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -161,26 +161,34 @@
       </div>
 
       <!-- Botones de acción -->
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
         <button onclick="devolverTurno()" class="bg-red-500 hover:bg-red-600 dark:bg-red-600 dark:hover:bg-red-700 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
           Devolver Turno
         </button>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <button onclick="atenderAhora()" class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2 col-span-2">
+          <button onclick="atenderAhora()" class="bg-green-600 hover:bg-green-700 dark:bg-green-700 dark:hover:bg-green-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 11c0-1.105.895-2 2-2h4a2 2 0 012 2v5a2 2 0 01-2 2h-4a2 2 0 01-2-2v-5zM7 9h3m-3 4h3" />
             </svg>
             Atender Siguiente
           </button>
-        </div>
         <button onclick="abrirModal()" class="bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
           </svg>
           Tomar Turno Manual
+        </button>
+        <button id="voice-command-button" onclick="iniciarReconocimientoVoz()" class="bg-purple-600 hover:bg-purple-700 dark:bg-purple-700 dark:hover:bg-purple-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2">
+            <svg id="mic-icon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-14 0m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v3a3 3 0 01-3 3z" />
+            </svg>
+            <span id="voice-command-text">Comando de Voz</span>
+            <svg id="mic-loading" class="animate-spin h-5 w-5 text-white hidden" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
         </button>
       </div>
 


### PR DESCRIPTION
Adds a new voice command feature to the turn management page.

A new microphone button allows the user to issue voice commands in Spanish.

- "cuál turno sigue": The application will announce the name of the client for the next turn using text-to-speech.
- "pase el turno en atencion": The application will move the current turn to the "in attention" section, effectively calling the "Atender Siguiente" action.

The implementation uses the Web Speech API for both speech recognition and synthesis. It includes UI feedback for the listening state and handles browser compatibility and potential errors.