### PR TITLE
feat: Implement satisfaction survey and comment analysis

### DIFF
--- a/admin/comentarios.js
+++ b/admin/comentarios.js
@@ -1,0 +1,86 @@
+import { supabase } from '../database.js';
+
+function getNegocioId() {
+    const id = document.body.dataset.negocioId;
+    if (!id) {
+        console.error('Error crítico: Atributo data-negocio-id no encontrado en el body.');
+        alert('Error de configuración: No se pudo identificar el negocio.');
+    }
+    return id;
+}
+
+const negocioId = getNegocioId();
+
+function renderComentarios(comentarios) {
+    const tablaBody = document.getElementById('tabla-comentarios');
+    if (!tablaBody) return;
+
+    if (comentarios.length === 0) {
+        tablaBody.innerHTML = '<tr><td colspan="5" class="py-4 text-center text-gray-500">No hay comentarios aún.</td></tr>';
+        return;
+    }
+
+    tablaBody.innerHTML = comentarios.map(comentario => {
+        const calificacionEstrellas = '★'.repeat(comentario.calificacion) + '☆'.repeat(5 - comentario.calificacion);
+        const sentimientoColor = comentario.sentimiento_score > 0.1 ? 'text-green-500' : comentario.sentimiento_score < -0.1 ? 'text-red-500' : 'text-gray-500';
+        const sentimientoTexto = comentario.sentimiento_score > 0.1 ? 'Positivo' : comentario.sentimiento_score < -0.1 ? 'Negativo' : 'Neutral';
+
+        return `
+            <tr>
+                <td class="py-2 px-4 border-b dark:border-gray-700">${comentario.nombre_cliente || 'Anónimo'}</td>
+                <td class="py-2 px-4 border-b dark:border-gray-700 text-yellow-500">${calificacionEstrellas}</td>
+                <td class="py-2 px-4 border-b dark:border-gray-700">${comentario.comentario || '<em>Sin comentario</em>'}</td>
+                <td class="py-2 px-4 border-b dark:border-gray-700 ${sentimientoColor}">${sentimientoTexto} (${comentario.sentimiento_score.toFixed(2)})</td>
+                <td class="py-2 px-4 border-b dark:border-gray-700">${new Date(comentario.created_at).toLocaleString('es-DO')}</td>
+            </tr>
+        `;
+    }).join('');
+}
+
+async function cargarComentarios() {
+    if (!negocioId) return;
+
+    try {
+        const { data, error } = await supabase
+            .from('comentarios')
+            .select('*')
+            .eq('negocio_id', negocioId)
+            .order('created_at', { ascending: false });
+
+        if (error) throw error;
+        renderComentarios(data);
+    } catch (error) {
+        console.error('Error al cargar comentarios:', error);
+        const tablaBody = document.getElementById('tabla-comentarios');
+        if (tablaBody) {
+            tablaBody.innerHTML = `<tr><td colspan="5" class="py-4 text-center text-red-500">Error al cargar los comentarios.</td></tr>`;
+        }
+    }
+}
+
+function suscribirseAComentarios() {
+    if (!negocioId) return;
+
+    const channel = supabase
+        .channel(`comentarios-negocio-${negocioId}`)
+        .on('postgres_changes', {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'comentarios',
+            filter: `negocio_id=eq.${negocioId}`,
+        },
+        (payload) => {
+            console.log('Nuevo comentario recibido:', payload.new.id);
+            cargarComentarios();
+        }
+        )
+        .subscribe();
+
+    return channel;
+}
+
+window.addEventListener('DOMContentLoaded', async () => {
+    if (!negocioId) return;
+    await cargarComentarios();
+    suscribirseAComentarios();
+});

--- a/comentarios_barberia005.html
+++ b/comentarios_barberia005.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Comentarios - TurnoRD Admin</title>
+
+  <!-- Base dinámico -->
+  <script>
+    const isGitHub = location.hostname.includes('github.io');
+    let baseHref = '/';
+    if (isGitHub) {
+      const pathParts = location.pathname.split('/');
+      if (pathParts.length > 1 && pathParts[1]) {
+        baseHref = `/${pathParts[1]}/`;
+      }
+    }
+    const base = document.createElement('base');
+    base.href = baseHref;
+    document.head.appendChild(base);
+  </script>
+
+  <link rel="icon" type="image/x-icon" href="imegenlogin/favicon.ico" />
+  <script type="module" src="auth-guard.js"></script>
+  <script src="assets/theme.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    function inicializarModoOscuro() {
+      const modoOscuro = localStorage.getItem('modoOscuro') === 'true';
+      document.documentElement.classList.toggle('dark', modoOscuro);
+    }
+    inicializarModoOscuro();
+    tailwind.config = { darkMode: 'class', theme: { extend: {} } };
+  </script>
+</head>
+<body class="bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200" data-negocio-id="barberia005">
+
+  <button id="toggleDarkMode" class="fixed top-4 right-4 z-50 p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200">
+    <!-- SVGs for dark mode toggle -->
+  </button>
+
+  <div class="flex min-h-screen">
+    <aside class="w-64 bg-primary-700 dark:bg-primary-700 text-white p-6 hidden md:block">
+      <h2 class="text-2xl font-bold mb-8">TurnoRD Admin</h2>
+      <nav class="space-y-4">
+        <a href="panel_barberia005.html" class="block hover:text-white rounded px-3 py-2">Inicio</a>
+        <a href="turno_barberia005.html" class="block hover:text-white rounded px-3 py-2">Turnos</a>
+        <a href="negocio_barberia005.html" class="block hover:text-white rounded px-3 py-2">Mi negocio</a>
+        <a href="comentarios_barberia005.html" class="block bg-white text-gray-900 font-semibold rounded px-3 py-2 shadow">Comentarios</a>
+        <a href="cierre_barberia005.html" id="cerrarSesion" class="block hover:text-red-400 mt-6 rounded px-3 py-2">Cerrar sesión</a>
+      </nav>
+    </aside>
+
+    <main class="flex-1 p-4 sm:p-6 w-full">
+      <h1 class="text-2xl font-bold mb-6">Comentarios de Clientes</h1>
+
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow p-4 overflow-x-auto">
+        <table class="min-w-full text-left">
+          <thead>
+            <tr>
+              <th class="py-2 px-4 border-b dark:border-gray-700 dark:text-gray-300">Cliente</th>
+              <th class="py-2 px-4 border-b dark:border-gray-700 dark:text-gray-300">Calificación</th>
+              <th class="py-2 px-4 border-b dark:border-gray-700 dark:text-gray-300">Comentario</th>
+              <th class="py-2 px-4 border-b dark:border-gray-700 dark:text-gray-300">Sentimiento</th>
+              <th class="py-2 px-4 border-b dark:border-gray-700 dark:text-gray-300">Fecha</th>
+            </tr>
+          </thead>
+          <tbody id="tabla-comentarios" class="dark:text-gray-300">
+            <!-- Las filas se insertarán desde admin/comentarios.js -->
+          </tbody>
+        </table>
+      </div>
+    </main>
+  </div>
+
+  <footer class="bg-primary-700 dark:bg-primary-700 text-white text-center text-sm py-4 mt-12 rounded-t-xl">
+    © 2025 TurnoRD Todo los derechos reservado • Hecho por <strong>LUIS ALFREDO CABRERA REYES</strong>
+  </footer>
+
+  <script type="module" src="admin/comentarios.js"></script>
+  <script>
+    document.getElementById('toggleDarkMode').addEventListener('click', function() {
+      if (window.theme && window.theme.toggleMode) window.theme.toggleMode();
+    });
+  </script>
+</body>
+</html>

--- a/configuracion_barberia005.html
+++ b/configuracion_barberia005.html
@@ -75,6 +75,12 @@
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" /></svg>
           Mi negocio
         </a>
+        <a href="comentarios_barberia005.html" class="flex items-center hover:text-white rounded px-3 py-2 transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+          Comentarios
+        </a>
         <a href="configuracion_barberia005.html" class="flex items-center bg-white text-gray-900 font-semibold rounded px-3 py-2 shadow transition-colors hidden">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h10a2 2 0 012 2v14a2 2 0 01-2 2z" /></svg>
           Configuración

--- a/create_comentarios_table.sql
+++ b/create_comentarios_table.sql
@@ -1,0 +1,40 @@
+-- Script: Tabla de comentarios y sentimiento para TurnoRD
+-- Ejecutar en el SQL Editor de Supabase
+
+BEGIN;
+
+-- =============================
+-- 1) Tabla de Comentarios
+-- =============================
+CREATE TABLE IF NOT EXISTS public.comentarios (
+  id BIGSERIAL PRIMARY KEY,
+  negocio_id TEXT NOT NULL,
+  turno_id BIGINT REFERENCES public.turnos(id) ON DELETE SET NULL,
+  nombre_cliente TEXT,
+  telefono_cliente TEXT,
+  comentario TEXT,
+  calificacion INT CHECK (calificacion >= 1 AND calificacion <= 5),
+  sentimiento_score NUMERIC(4, 2) DEFAULT 0.00, -- Rango de -1 (negativo) a 1 (positivo)
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_comentarios_negocio_id ON public.comentarios(negocio_id);
+CREATE INDEX IF NOT EXISTS idx_comentarios_turno_id ON public.comentarios(turno_id);
+
+-- RLS
+ALTER TABLE public.comentarios ENABLE ROW LEVEL SECURITY;
+
+-- Políticas de seguridad
+DROP POLICY IF EXISTS "Permitir acceso de lectura a todos" ON public.comentarios;
+CREATE POLICY "Permitir acceso de lectura a todos"
+ON public.comentarios
+FOR SELECT
+USING (true);
+
+DROP POLICY IF EXISTS "Permitir inserción a todos" ON public.comentarios;
+CREATE POLICY "Permitir inserción a todos"
+ON public.comentarios
+FOR INSERT
+WITH CHECK (true);
+
+COMMIT;

--- a/negocio_barberia005.html
+++ b/negocio_barberia005.html
@@ -123,6 +123,12 @@
           </svg>
           Mi negocio
         </a>
+        <a href="comentarios_barberia005.html" class="flex items-center hover:text-white rounded px-3 py-2 transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+          </svg>
+          Comentarios
+        </a>
         <a href="configuracion_barberia005.html" class="flex items-center hover:text-white rounded px-3 py-2 transition-colors hidden">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />

--- a/panel_barberia005.html
+++ b/panel_barberia005.html
@@ -89,6 +89,7 @@
         <a href="panel_barberia005.html" class="block hover:text-white rounded px-3 py-2">Inicio</a>
         <a href="turno_barberia005.html" class="block bg-white text-gray-900 font-semibold rounded px-3 py-2 shadow">Turnos</a>
         <a href="negocio_barberia005.html" class="block hover:text-white rounded px-3 py-2">Mi negocio</a>
+        <a href="comentarios_barberia005.html" class="block hover:text-white rounded px-3 py-2">Comentarios</a>
         <a href="configuracion_barberia005.html" class="block hover:text-white rounded px-3 py-2 hidden">Configuración</a>
         <a href="cierre_barberia005.html" id="cerrarSesion" class="block hover:text-red-400 mt-6 rounded px-3 py-2">Cerrar sesión</a>
       </nav>

--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -100,6 +100,7 @@
         <a href="panel_barberia005.html" class="block hover:text-white rounded px-3 py-2">Inicio</a>
         <a href="turno_barberia005.html" class="block bg-white text-gray-900 font-semibold rounded px-3 py-2 shadow">Turnos</a>
         <a href="negocio_barberia005.html" class="block hover:text-white rounded px-3 py-2">Mi negocio</a>
+        <a href="comentarios_barberia005.html" class="block hover:text-white rounded px-3 py-2">Comentarios</a>
         <a href="configuracion_barberia005.html" class="block hover:text-white rounded px-3 py-2 hidden">Configuración</a>
         <a href="cierre_barberia005.html" id="cerrarSesion" class="block hover:text-red-400 mt-6 rounded px-3 py-2">Cerrar sesión</a>
       </nav>

--- a/usuario_barberia005.html
+++ b/usuario_barberia005.html
@@ -114,6 +114,41 @@
   <div id="listaEspera" class="space-y-2 mt-4"></div>
   <div id="mensaje-turno"></div>
 </div>
+
+<!-- Modal de Comentario -->
+<div id="comentario-modal" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 hidden px-4">
+  <div class="bg-white dark:bg-gray-800 text-blue-900 dark:text-blue-300 rounded-2xl w-full max-w-md p-6 relative shadow-2xl">
+    <button id="btn-cerrar-comentario-modal" class="absolute top-4 right-4 text-blue-900 dark:text-blue-300 text-2xl font-bold" type="button">&times;</button>
+    <h2 class="text-xl font-bold mb-4 text-center">¡Gracias por tu visita!</h2>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4 text-center">Nos encantaría saber cómo fue tu experiencia.</p>
+    <form id="formComentario" class="space-y-4">
+      <div>
+        <label class="block text-sm text-center font-medium mb-2 dark:text-gray-300">Calificación</label>
+        <div class="flex flex-row-reverse justify-center items-center rating">
+          <input type="radio" id="star5" name="rating" value="5" class="hidden peer" required /><label for="star5" class="cursor-pointer text-4xl text-gray-400 peer-hover:text-yellow-400 peer-checked:text-yellow-500 hover:text-yellow-400">★</label>
+          <input type="radio" id="star4" name="rating" value="4" class="hidden peer" /><label for="star4" class="cursor-pointer text-4xl text-gray-400 peer-hover:text-yellow-400 peer-checked:text-yellow-500 hover:text-yellow-400">★</label>
+          <input type="radio" id="star3" name="rating" value="3" class="hidden peer" /><label for="star3" class="cursor-pointer text-4xl text-gray-400 peer-hover:text-yellow-400 peer-checked:text-yellow-500 hover:text-yellow-400">★</label>
+          <input type="radio" id="star2" name="rating" value="2" class="hidden peer" /><label for="star2" class="cursor-pointer text-4xl text-gray-400 peer-hover:text-yellow-400 peer-checked:text-yellow-500 hover:text-yellow-400">★</label>
+          <input type="radio" id="star1" name="rating" value="1" class="hidden peer" /><label for="star1" class="cursor-pointer text-4xl text-gray-400 peer-hover:text-yellow-400 peer-checked:text-yellow-500 hover:text-yellow-400">★</label>
+        </div>
+        <style>
+          .rating:not(:hover) input:checked ~ label,
+          .rating:hover input:hover ~ label {
+            color: #f59e0b; /* yellow-500 */
+          }
+        </style>
+      </div>
+      <div>
+        <label for="comentario" class="block text-sm font-medium mb-1 dark:text-gray-300">Comentario (opcional)</label>
+        <textarea id="comentario" name="comentario" rows="4" placeholder="Cuéntanos más..." class="w-full p-3 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-600 dark:bg-gray-700 dark:border-gray-600 dark:text-white"></textarea>
+      </div>
+      <button type="submit" class="bg-blue-900 dark:bg-blue-700 text-white w-full py-3 rounded-lg hover:bg-blue-800 dark:hover:bg-blue-600 transition font-semibold">
+        Enviar Comentario
+      </button>
+    </form>
+  </div>
+</div>
+
 <!-- Errores -->
 <script>
   window.addEventListener('error', e => {


### PR DESCRIPTION
This commit introduces a new satisfaction survey feature that allows customers to provide feedback after their turn is marked as 'Atendido'.

The main changes are:
- A new `comentarios` table is defined in `create_comentarios_table.sql` to store customer feedback, including a rating, a text comment, and a sentiment score.
- The user page (`usuario_barberia005.html`) now displays a modal for the satisfaction survey when a customer's turn is complete.
- The user-side JavaScript (`usuario/usuario.js`) has been updated to handle the survey submission. It includes a simple keyword-based sentiment analysis to score the comment.
- A new administrator page (`comentarios_barberia005.html`) has been created to display all submitted comments in a table.
- The `admin/comentarios.js` script fetches and renders the comments, including a visual representation of the rating and the sentiment score.
- The sidebars of all relevant admin pages have been updated to include a link to the new 'Comentarios' page for easy access.