### PR TITLE
feat: Implement browser notifications and improve turn list layout

### DIFF
--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -338,7 +338,7 @@
             </svg>
             Turnos en Atención
         </h2>
-        <div id="listaAtencion" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div id="listaAtencion" class="flex flex-col gap-4">
             <!-- Los turnos en atención se agregarán aquí dinámicamente -->
         </div>
       </div>
@@ -361,7 +361,7 @@
             </button>
           </div>
         </div>
-        <div id="listaEspera" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div id="listaEspera" class="flex flex-col gap-4">
           <!-- Turnos agregados aparecerán aquí -->
           <!-- Ejemplo de tarjeta de turno (se generará dinámicamente) -->
           <div class="hidden bg-blue-50 dark:bg-blue-900/30 p-4 rounded-lg shadow-sm border border-blue-100 dark:border-blue-800 transition-all hover:shadow-md">


### PR DESCRIPTION
This commit introduces two main features:

1.  A browser notification system for users.
    - When a user's turn is approaching (i.e., they are first or second in the waiting queue), a browser notification is sent to them.
    - The notification informs them that they can head to the barbershop.
    - Permission for notifications is requested when the user takes a turn or loads the page with an active turn.
    - LocalStorage is used to prevent sending duplicate notifications for the same turn.

2.  An improved layout for the turn lists in the admin panel.
    - The "En atención" and "En espera" lists in `turno_barberia005.html` are now displayed as single vertical columns instead of a grid.
    - This provides a clearer top-to-bottom view of the turn flow.