### PR TITLE
fix: Revert turn list layout to grid view

### DIFF
--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -338,7 +338,7 @@
             </svg>
             Turnos en Atención
         </h2>
-        <div id="listaAtencion" class="flex flex-col gap-4">
+        <div id="listaAtencion" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             <!-- Los turnos en atención se agregarán aquí dinámicamente -->
         </div>
       </div>
@@ -361,7 +361,7 @@
             </button>
           </div>
         </div>
-        <div id="listaEspera" class="flex flex-col gap-4">
+        <div id="listaEspera" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           <!-- Turnos agregados aparecerán aquí -->
           <!-- Ejemplo de tarjeta de turno (se generará dinámicamente) -->
           <div class="hidden bg-blue-50 dark:bg-blue-900/30 p-4 rounded-lg shadow-sm border border-blue-100 dark:border-blue-800 transition-all hover:shadow-md">


### PR DESCRIPTION
This commit reverts the layout of the turn lists in the admin panel (`turno_barberia005.html`) back to the original grid system.

The previous change to a single-column flex layout was not preferred by the user. This commit restores the `grid` and `grid-cols-*` classes to the `listaAtencion` and `listaEspera` divs, matching the original design.