### PR TITLE
fix: Hide voice command button

### DIFF
--- a/turno_barberia005.html
+++ b/turno_barberia005.html
@@ -184,7 +184,7 @@
           </svg>
           Tomar Turno Manual
         </button>
-        <button id="voice-command-button" onclick="iniciarReconocimientoVoz()" class="bg-purple-600 hover:bg-purple-700 dark:bg-purple-700 dark:hover:bg-purple-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2">
+        <button id="voice-command-button" onclick="iniciarReconocimientoVoz()" class="bg-purple-600 hover:bg-purple-700 dark:bg-purple-700 dark:hover:bg-purple-800 text-white py-3 rounded-xl font-semibold shadow-md transition-all flex items-center justify-center gap-2 hidden">
             <svg id="mic-icon" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11a7 7 0 01-14 0m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v3a3 3 0 01-3 3z" />
             </svg>


### PR DESCRIPTION
This commit hides the voice command button from the main actions section in the turn management view as per user request.